### PR TITLE
feat: add claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This repository builds a custom Docker image of Caddy web server with Docker label support and
+Cloudflare DNS integration. The image automatically configures itself as a reverse proxy by reading
+Docker container labels.
+
+Key features:
+
+- Extends official Caddy image with `caddy-docker-proxy` and `cloudflare` plugins
+- Multi-architecture support (linux/amd64, linux/arm64)
+- Automated CI/CD pipeline pushing to GitHub Container Registry
+
+## Development Commands
+
+### Setup
+
+```bash
+# With mise (recommended)
+mise run setup  # Installs tools and npm dependencies
+
+# Without mise
+npm install
+```
+
+### Building
+
+```bash
+# Build Docker image locally
+docker build -t caddy-labels:latest .
+
+# Test multi-platform build (like CI)
+docker buildx build --platform linux/amd64,linux/arm64 .
+```
+
+### Linting
+
+```bash
+npm run lint          # Run all linters
+npm run lint:docker   # Lint Dockerfile
+npm run lint:markdown # Lint Markdown files
+npm run lint:yaml     # Lint YAML workflows
+npm run lint:fix      # Auto-fix Markdown issues
+```
+
+### Version Updates
+
+To update Caddy version:
+
+1. Edit `ARG CADDY_VERSION=2.10.0` in Dockerfile:1
+2. Commit with message like: `fix: upgrade to Caddy 2.10.0 for Go 1.24 compatibility`
+
+## Architecture
+
+### Docker Build Process
+
+The Dockerfile uses a multi-stage build:
+
+1. **Builder stage**: Uses `caddy:${CADDY_VERSION}-builder` to compile Caddy with plugins
+2. **Final stage**: Copies compiled binary to minimal `caddy:${CADDY_VERSION}-alpine` image
+
+### CI/CD Pipeline
+
+- **PR builds**: Test multi-platform builds without pushing
+- **Main branch**: Builds and pushes to `ghcr.io/cpritchett/caddy-labels` with tags:
+  - `latest`
+  - `YYYYMMDD-HHmmss` (UTC timestamp)
+  - Caddy version (e.g., `2.10.0`)
+
+### Docker Label Configuration
+
+The image reads Docker labels and translates them to Caddy configuration. Example:
+
+```yaml
+labels:
+  caddy: "*.example.com"
+  caddy.reverse_proxy: "{{upstreams 80}}"
+  caddy.tls.dns: "cloudflare"
+```
+
+## Key Files
+
+- `Dockerfile`: Main build configuration
+- `package.json`: Development scripts and linting tools
+- `.github/workflows/build.yaml`: CI/CD pipeline for Docker builds
+- `.github/workflows/lint.yaml`: Code quality checks
+- `.mise.toml`: Tool version management (Node.js, hadolint, etc.)
+
+## Important Notes
+
+- This is a Docker image project with no application code
+- All development dependencies are Node.js-based for linting/tooling
+- Commits must follow conventional commit format (enforced by commitlint)
+- Pre-commit hooks run linters automatically via Husky

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ztimson/caddy-labels
+# cpritchett/caddy-labels
 
 <!-- Header -->
 <div id="top" align="center">
@@ -12,9 +12,9 @@
   Caddy with Docker Label Support & Cloudflare
 
   <!-- Repo badges -->
-  [![Version](https://img.shields.io/badge/dynamic/json.svg?label=Version&style=for-the-badge&url=https://git.zakscode.com/api/v1/repos/ztimson/caddy-labels/tags&query=$[0].name)](https://git.zakscode.com/ztimson/caddy-labels/tags)
-  [![Pull Requests](https://img.shields.io/badge/dynamic/json.svg?label=Pull%20Requests&style=for-the-badge&url=https://git.zakscode.com/api/v1/repos/ztimson/caddy-labels&query=open_pr_counter)](https://git.zakscode.com/ztimson/caddy-labels/pulls)
-  [![Issues](https://img.shields.io/badge/dynamic/json.svg?label=Issues&style=for-the-badge&url=https://git.zakscode.com/api/v1/repos/ztimson/caddy-labels&query=open_issues_count)](https://git.zakscode.com/ztimson/caddy-labels/issues)
+  [![Version](https://img.shields.io/badge/dynamic/json.svg?label=Version&style=for-the-badge&url=https://api.github.com/repos/cpritchett/caddy-labels/tags&query=$[0].name)](https://github.com/cpritchett/caddy-labels/tags)
+  [![Pull Requests](https://img.shields.io/github/issues-pr/cpritchett/caddy-labels?style=for-the-badge)](https://github.com/cpritchett/caddy-labels/pulls)
+  [![Issues](https://img.shields.io/github/issues/cpritchett/caddy-labels?style=for-the-badge)](https://github.com/cpritchett/caddy-labels/issues)
 
 </div>
 
@@ -93,7 +93,7 @@ See [caddy-docker-proxy](github.com/lucaslorentz/caddy-docker-proxy) for more in
 ```yml
 services:
   caddy:
-    image: ztimson/caddy-labels:latest
+    image: cpritchett/caddy-labels:latest
     environment:
       CADDY_INGRESS_NETWORKS: proxy_network
       TZ: America/Toronto
@@ -132,7 +132,7 @@ volumes:
 #### Build Instructions
 
 1. Update desired version number in Dockerfile
-1. Build docker image: `docker build -t ztimson/caddy-labels:latest .`
+1. Build docker image: `docker build -t cpritchett/caddy-labels:latest .`
 
 #### Linting
 
@@ -176,6 +176,6 @@ npm run lint:fix      # Auto-fix Markdown issues
 
 ## License
 
-Copyright © 2023 Zakary Timson | Available under MIT Licensing
+Copyright © 2023 cpritchett | Available under MIT Licensing
 
 See the [license](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   Caddy with Docker Label Support & Cloudflare
 
   <!-- Repo badges -->
-  [![Version](https://img.shields.io/badge/dynamic/json.svg?label=Version&style=for-the-badge&url=https://api.github.com/repos/cpritchett/caddy-labels/tags&query=$[0].name)](https://github.com/cpritchett/caddy-labels/tags)
+  [![Version](https://img.shields.io/github/v/tag/cpritchett/caddy-labels?style=for-the-badge&label=Version)](https://github.com/cpritchett/caddy-labels/tags)
   [![Pull Requests](https://img.shields.io/github/issues-pr/cpritchett/caddy-labels?style=for-the-badge)](https://github.com/cpritchett/caddy-labels/pulls)
   [![Issues](https://img.shields.io/github/issues/cpritchett/caddy-labels?style=for-the-badge)](https://github.com/cpritchett/caddy-labels/issues)
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://git.zakscode.com/ztimson/caddy-labels.git"
+    "url": "https://github.com/cpritchett/caddy-labels.git"
   },
   "keywords": [
     "caddy",
@@ -46,6 +46,6 @@
     "cloudflare",
     "cloudflare"
   ],
-  "author": "ztimson",
+  "author": "cpritchett",
   "license": "MIT"
 }


### PR DESCRIPTION
This pull request includes updates to documentation and metadata to reflect a repository ownership transfer from `ztimson` to `cpritchett`. It also introduces a new `CLAUDE.md` file to provide development guidance for contributors. Below is a summary of the most important changes:

### Repository Ownership Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Updated repository name, image references, and badges to reflect the new owner (`cpritchett`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R17) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R96) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L135-R135)
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L40-R40): Changed repository URL and author metadata to reflect the new ownership. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L40-R40) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49-R49)

### New Contributor Guide:

* [`CLAUDE.md`](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1-R97): Added a new file providing detailed guidance on project setup, development commands, architecture, CI/CD pipeline, and Docker label configuration. This file is designed to help contributors understand and work efficiently within the repository.