### PR TITLE
fix: update dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,6 +30,7 @@ commitlint.config.mjs
 .eslintrc*
 .markdownlint*
 .hadolint.yaml
+renovate.json
 
 # Tool configurations
 .mise.toml

--- a/.dockerignore
+++ b/.dockerignore
@@ -30,7 +30,7 @@ commitlint.config.mjs
 .eslintrc*
 .markdownlint*
 .hadolint.yaml
-renovate.json
+renovate.json*
 
 # Tool configurations
 .mise.toml


### PR DESCRIPTION
This pull request includes a small change to the `.dockerignore` file. The change adds `renovate.json` to the list of ignored files.