### PR TITLE
feat: Implement image versioning and GitHub Releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,11 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
-      contents: read
+      contents: write # Changed from read to write for release creation
       packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for git describe to get tags
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -65,20 +67,38 @@ jobs:
       - name: Extract Caddy version
         id: caddy-version
         run: |
-          VERSION=$(grep "ARG CADDY_VERSION" Dockerfile | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+\(-[A-Za-z0-9.-]\+\)\?\(\+[A-Za-z0-9.-]\+\)\?')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          CADDY_VERSION_RAW=$(grep "ARG CADDY_VERSION" Dockerfile | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+\(-[A-Za-z0-9.-]\+\)\?\(\+[A-Za-z0-9.-]\+\)\?')
+          echo "caddy_version_raw=$CADDY_VERSION_RAW" >> $GITHUB_OUTPUT
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          VERSION_TAG="${CADDY_VERSION_RAW}-${SHORT_SHA}"
+          echo "version_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
+        id: build-and-push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: |
             ${{ steps.meta.outputs.tags }}
-            ghcr.io/${{ github.repository }}:${{ steps.caddy-version.outputs.version }}
+            ghcr.io/${{ github.repository }}:${{ steps.caddy-version.outputs.version_tag }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.caddy-version.outputs.version_tag }}
+          release_name: Release ${{ steps.caddy-version.outputs.version_tag }}
+          body: |
+            Image released with Caddy version ${{ steps.caddy-version.outputs.caddy_version_raw }} and commit ${{ steps.caddy-version.outputs.short_sha }}.
+            Image tag: ghcr.io/${{ github.repository }}:${{ steps.caddy-version.outputs.version_tag }}
+          draft: false
+          prerelease: false
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   - [Setup](#setup)
     - [Production](#production)
     - [Development](#development)
+  - [Versioning](#versioning)
   - [License](#license)
 
 ## About
@@ -172,6 +173,21 @@ npm run lint:fix      # Auto-fix Markdown issues
 
 - Pre-commit: Runs all linters before allowing commits
 - Commit-msg: Validates commit message format
+
+## Versioning
+
+This project uses a versioning scheme based on the upstream Caddy version and the Git commit SHA.
+
+- **Image Tags:** Docker images are tagged in the format `{CADDY_VERSION}-{SHORT_SHA}`. For example, `2.10.0-a1b2c3d`.
+  - `{CADDY_VERSION}`: The version of Caddy used in the image (e.g., `2.10.0`).
+  - `{SHORT_SHA}`: The short Git commit SHA representing the state of this repository when the image was built (e.g., `a1b2c3d`).
+- **GitHub Releases:** For every image pushed to GHCR with this tag format, a corresponding GitHub Release is created with the same tag. This allows for easy tracking of changes and provides a clear link between an image and its source code.
+- **`latest` Tag:** The `latest` tag will always point to the most recent image built from the `main` branch.
+
+This approach ensures that:
+- Each image build from `main` is uniquely identifiable.
+- Users can easily find the exact source code that corresponds to a specific image version via the GitHub Release.
+- It's clear which version of Caddy is included.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -178,15 +178,22 @@ npm run lint:fix      # Auto-fix Markdown issues
 
 This project uses a versioning scheme based on the upstream Caddy version and the Git commit SHA.
 
-- **Image Tags:** Docker images are tagged in the format `{CADDY_VERSION}-{SHORT_SHA}`. For example, `2.10.0-a1b2c3d`.
+- **Image Tags:** Docker images are tagged in the format `{CADDY_VERSION}-{SHORT_SHA}`.
+  For example, `2.10.0-a1b2c3d`.
   - `{CADDY_VERSION}`: The version of Caddy used in the image (e.g., `2.10.0`).
-  - `{SHORT_SHA}`: The short Git commit SHA representing the state of this repository when the image was built (e.g., `a1b2c3d`).
-- **GitHub Releases:** For every image pushed to GHCR with this tag format, a corresponding GitHub Release is created with the same tag. This allows for easy tracking of changes and provides a clear link between an image and its source code.
-- **`latest` Tag:** The `latest` tag will always point to the most recent image built from the `main` branch.
+  - `{SHORT_SHA}`: The short Git commit SHA representing the state of this repository when the image
+    was built (e.g., `a1b2c3d`).
+- **GitHub Releases:** For every image pushed to GHCR with this tag format, a corresponding GitHub
+  Release is created with the same tag. This allows for easy tracking of changes and provides a
+  clear link between an image and its source code.
+- **`latest` Tag:** The `latest` tag will always point to the most recent image built from the
+  `main` branch.
 
 This approach ensures that:
+
 - Each image build from `main` is uniquely identifiable.
-- Users can easily find the exact source code that corresponds to a specific image version via the GitHub Release.
+- Users can easily find the exact source code that corresponds to a specific image version via the
+  GitHub Release.
 - It's clear which version of Caddy is included.
 
 ## License


### PR DESCRIPTION
This pull request introduces changes to improve the CI/CD pipeline and enhance documentation for versioning. Key updates include modifications to the GitHub Actions workflow to enable automatic GitHub Releases, updates to Docker image tagging, and the addition of a new "Versioning" section in the `README.md`.

### CI/CD Pipeline Enhancements:
* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L38-R44): Changed `contents` permission from `read` to `write` to enable release creation. Added `fetch-depth: 0` to the checkout step for fetching tags.
* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L68-R103): Updated the Docker image tagging mechanism to include both the Caddy version and the short Git commit SHA. Added steps to create a GitHub Release for each image build, including detailed release notes.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R177-R191): Added a new "Versioning" section explaining the project's versioning scheme, including Docker image tags, GitHub Releases, and the `latest` tag. This ensures users can easily identify the source code and Caddy version for each image.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R28): Updated the table of contents to include the new "Versioning" section.